### PR TITLE
fix: use direct image URLs instead of local paths in README.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![Lint](https://github.com/pesu-dev/auth/actions/workflows/lint.yaml/badge.svg)](https://github.com/pesu-dev/auth/actions/workflows/lint.yaml)
 [![Deploy](https://github.com/pesu-dev/auth/actions/workflows/deploy.yaml/badge.svg)](https://github.com/pesu-dev/auth/actions/workflows/deploy.yaml)
 
-![Docker Automated build](https://img.shields.io/docker/automated/aditeyabaral/pesu-auth?logo=docker)
-![Docker Image Version (tag)](https://img.shields.io/docker/v/aditeyabaral/pesu-auth/latest?logo=docker&label=build%20commit)
-![Docker Image Size (tag)](https://img.shields.io/docker/image-size/aditeyabaral/pesu-auth/latest?logo=docker)
+[![Docker Automated build](https://img.shields.io/docker/automated/aditeyabaral/pesu-auth?logo=docker)](https://hub.docker.com/r/aditeyabaral/pesu-auth/builds)
+[![Docker Image Version (tag)](https://img.shields.io/docker/v/aditeyabaral/pesu-auth/latest?logo=docker&label=build%20commit)](https://hub.docker.com/r/aditeyabaral/pesu-auth/tags)
+[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/aditeyabaral/pesu-auth/latest?logo=docker)](https://hub.docker.com/r/aditeyabaral/pesu-auth)
 
 A simple API to authenticate PESU credentials using PESU Academy.
 

--- a/app/util.py
+++ b/app/util.py
@@ -12,7 +12,11 @@ def convert_readme_to_html():
     readme_content = re.sub(r":\w+: ", "", readme_content)
     with open("README_tmp.md", "w") as f:
         f.write(readme_content)
-    html = gh_md_to_html.main("README_tmp.md").strip()
+    html = gh_md_to_html.main(
+        "README_tmp.md",
+        enable_image_downloading=False,
+        image_paths=None,
+    ).strip()
     with open("README.html", "w") as f:
         f.write(html)
     logging.info("README.md converted to HTML successfully.")


### PR DESCRIPTION
- README.html now uses direct paths to the SVG badges, and now render properly instead of just showing the links.

<img width="1831" height="981" alt="image" src="https://github.com/user-attachments/assets/80d92c1f-0e0c-4496-9bbe-9b19872dc666" />
