### PR TITLE
Cache README HTML in memory at startup to optimize (#74)

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -159,7 +159,6 @@ async def authenticate(payload: RequestModel):
     profile = payload.profile
     fields = payload.fields
 
-
     # Authenticate the user
     authentication_result = {"timestamp": current_time}
     logging.info(f"Authenticating user={username} with PESU Academy...")

--- a/app/app.py
+++ b/app/app.py
@@ -32,10 +32,10 @@ async def lifespan(app: FastAPI):
     try:
         logging.info("PESUAuth API startup: Generating README HTML cache...")
         enabled_readme_cache = util.convert_readme_to_html()
-        logging.info("✅ README HTML cached in memory.")
+        logging.info("README HTML cached in memory.")
     except Exception:
         logging.exception(
-            "❌ Failed to generate README HTML at startup; /readme will attempt on-demand conversion."
+            "Failed to generate README HTML at startup; /readme will attempt on-demand conversion."
         )
         enabled_readme_cache = None
     yield
@@ -153,11 +153,14 @@ async def authenticate(payload: RequestModel):
     - fields (List[str], optional): Specific profile fields to include in the response.
     """
     current_time = datetime.datetime.now(IST)
+    # Input has already been validated by the RequestModel
     username = payload.username
     password = payload.password
     profile = payload.profile
     fields = payload.fields
 
+
+    # Authenticate the user
     authentication_result = {"timestamp": current_time}
     logging.info(f"Authenticating user={username} with PESU Academy...")
     authentication_result.update(
@@ -166,6 +169,7 @@ async def authenticate(payload: RequestModel):
         )
     )
 
+    # Validate the response
     try:
         authentication_result = ResponseModel.model_validate(authentication_result)
         logging.info(f"Returning auth result for user={username}: {authentication_result}")
@@ -186,6 +190,7 @@ def main():
     """
     Main function to run the FastAPI application with command line arguments.
     """
+    # Set up argument parser for command line arguments
     parser = argparse.ArgumentParser(
         description="PESUAuth API - A simple API to authenticate PESU credentials using PESU Academy."
     )
@@ -208,13 +213,14 @@ def main():
     )
     args = parser.parse_args()
 
+    # Set up logging configuration
     logging_level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(
         level=logging_level,
         format="%(asctime)s - %(levelname)s - %(filename)s:%(funcName)s:%(lineno)d - %(message)s",
         filemode="w",
     )
-
+    # Run the app
     uvicorn.run("app.app:app", host=args.host, port=args.port, reload=args.debug)
 
 

--- a/app/util.py
+++ b/app/util.py
@@ -1,29 +1,25 @@
 import re
 import logging
-import gh_md_to_html
 from pathlib import Path
+import gh_md_to_html
 
 def convert_readme_to_html() -> str:
-    """
-    Read README.md, convert to HTML, and return the HTML string.
-    """
-    logging.info("Beginning conversion of README.md to HTML in memory...")
+    
+    #Read README.md, convert to HTML, and return the HTML string.
+    
+    logging.info("Converting README.md to HTML...")
 
-    # Read and preprocess README.md content
-    readme_content = Path("README.md").read_text(encoding="utf-8").strip()
-    readme_content = re.sub(r":\w+: ", "", readme_content)
-
-    # Write a temporary markdown file for the converter
-    temp_md = Path("README_tmp.md")
-    temp_md.write_text(readme_content, encoding="utf-8")
+    # Read and clean the markdown content
+    readme_md = Path("README.md").read_text(encoding="utf-8").strip()
+    cleaned_md = re.sub(r":\w+: ", "", readme_md)
 
     # Convert markdown to HTML
-    html = gh_md_to_html.main(
-        str(temp_md),
+    html_output = gh_md_to_html.main(
+        cleaned_md,
         enable_image_downloading=False,
         image_paths=None,
+        origin_type="string",  
     ).strip()
 
-    logging.info("README.md converted to HTML successfully in memory.")
-
-    return html
+    logging.info("README.md converted to HTML successfully.")
+    return html_output

--- a/app/util.py
+++ b/app/util.py
@@ -4,8 +4,11 @@ from pathlib import Path
 import gh_md_to_html
 
 def convert_readme_to_html() -> str:
-    
-    #Read README.md, convert to HTML, and return the HTML string.
+     
+    """
+    Convert the README.md file to HTML and save it as README.html so that it can be rendered on the home page.
+    Read README.md, convert to HTML, and return the HTML string.
+    """
     
     logging.info("Converting README.md to HTML...")
 

--- a/app/util.py
+++ b/app/util.py
@@ -1,22 +1,29 @@
 import re
 import logging
 import gh_md_to_html
+from pathlib import Path
 
+def convert_readme_to_html() -> str:
+    """
+    Read README.md, convert to HTML, and return the HTML string.
+    """
+    logging.info("Beginning conversion of README.md to HTML in memory...")
 
-def convert_readme_to_html():
-    """
-    Convert the README.md file to HTML and save it as README.html so that it can be rendered on the home page.
-    """
-    logging.info("Beginning conversion of README.md to HTML...")
-    readme_content = open("README.md").read().strip()
+    # Read and preprocess README.md content
+    readme_content = Path("README.md").read_text(encoding="utf-8").strip()
     readme_content = re.sub(r":\w+: ", "", readme_content)
-    with open("README_tmp.md", "w") as f:
-        f.write(readme_content)
+
+    # Write a temporary markdown file for the converter
+    temp_md = Path("README_tmp.md")
+    temp_md.write_text(readme_content, encoding="utf-8")
+
+    # Convert markdown to HTML
     html = gh_md_to_html.main(
-        "README_tmp.md",
+        str(temp_md),
         enable_image_downloading=False,
         image_paths=None,
     ).strip()
-    with open("README.html", "w") as f:
-        f.write(html)
-    logging.info("README.md converted to HTML successfully.")
+
+    logging.info("README.md converted to HTML successfully in memory.")
+
+    return html


### PR DESCRIPTION
At startup, we now convert the README to HTML and keep it in memory, so each request to /readme simply returns the cached content. This eliminates repeated Markdown-to-HTML conversions and file reads on every hit, reducing latency and improving overall performance. To accomplish this, convert_readme_to_html() was updated to return the HTML string, and the FastAPI lifespan handler now loads it once at launch before the /readme route serves it from memory.